### PR TITLE
Fix sidebar indentation to align sibling folder and file icons

### DIFF
--- a/SoDaReloaded.sublime-theme
+++ b/SoDaReloaded.sublime-theme
@@ -563,7 +563,7 @@
         "class": "sidebar_tree",
         "row_padding": [0, 4],
         "indent": 20,
-        "indent_offset": 17,
+        "indent_offset": 0,
         "indent_top_level": false,
         "dark_content": true
     },
@@ -690,9 +690,9 @@
     // Sidebar group closed
     {
         "class": "disclosure_button_control",
-        "content_margin": [8, 8],
+        "content_margin": [0, 0],
         "layer0.texture": "Theme - SoDaReloaded/images/folder-closed.png",
-        "layer0.opacity": 1.0,
+        "layer0.opacity": 0,
         "layer0.inner_margin": 0
     },
     {
@@ -727,8 +727,8 @@
     {
         "class": "icon_folder",
         "layer0.texture": "Theme - SoDaReloaded/images/folder-closed.png",
-        "layer0.opacity": 0,
-        "content_margin": 0
+        "layer0.opacity": 1.0,
+        "content_margin": [8, 8]
     },
     {
         "class": "icon_folder",


### PR DESCRIPTION
I fat-fingered the pull request message before entering the full comment. In any case, this makes a couple tweaks to align the sibling file and folder icons in a directory. Previously, the files would be indented relative to their sibling folders, which IMHO doesn't accurately reflect the true hierarchy. Here's what the changes look like:

![aligned](https://cloud.githubusercontent.com/assets/137289/6840587/9b22ea56-d351-11e4-9ae9-75d837d878a8.png)
