### PR TITLE
Fix PHP sidebar icon context: from source.php to embedded.php

### DIFF
--- a/icons/icon_php.tmPreferences
+++ b/icons/icon_php.tmPreferences
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>scope</key>
-    <string>embedded.php</string>
+    <string>embedding.php</string>
     <key>settings</key>
     <dict>
         <key>icon</key>

--- a/icons/icon_php.tmPreferences
+++ b/icons/icon_php.tmPreferences
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>scope</key>
-    <string>source.php</string>
+    <string>embedded.php</string>
     <key>settings</key>
     <dict>
         <key>icon</key>


### PR DESCRIPTION
Generic cog icon for PHP files in the sidebar, which is not correct. The proper context for such files in the icon definition is `embedding.php`. Even when Sublime shows `source.php` as one of the contexts for PHP sources, it seems themes sidebar icons only take first context into account (`embedding.php`).
