### PR TITLE
Remove sidebar left margin

### DIFF
--- a/SoDaReloaded Dark.sublime-theme
+++ b/SoDaReloaded Dark.sublime-theme
@@ -556,16 +556,15 @@
         "layer0.texture": "Theme - SoDaReloaded/dark/images/sidebar-bg.png",
         "layer0.opacity": 1.0,
         "layer0.inner_margin": [1, 1, 2, 1],
-        "content_margin": [7, 4, 0, 0]
+        "content_margin": [0, 0, 1, 0]
     },
     // Sidebar tree
     {
         "class": "sidebar_tree",
-        "row_padding": [0, 4],
-        "indent": 20,
-        "indent_offset": 0,
-        "indent_top_level": true,
-        "dark_content": true
+        "row_padding": [8, 3],
+        "indent": 15,
+        "indent_offset": 15,
+        "indent_top_level": false
     },
     // Sidebar rows
     {

--- a/SoDaReloaded Light.sublime-theme
+++ b/SoDaReloaded Light.sublime-theme
@@ -556,16 +556,15 @@
         "layer0.texture": "Theme - SoDaReloaded/light/images/sidebar-bg.png",
         "layer0.opacity": 1.0,
         "layer0.inner_margin": [1, 1, 2, 1],
-        "content_margin": [7, 4, 0, 0]
+        "content_margin": [0, 0, 1, 0]
     },
     // Sidebar tree
     {
         "class": "sidebar_tree",
-        "row_padding": [0, 4],
-        "indent": 20,
-        "indent_offset": 0,
-        "indent_top_level": true,
-        "dark_content": true
+        "row_padding": [8, 3],
+        "indent": 15,
+        "indent_offset": 15,
+        "indent_top_level": false
     },
     // Sidebar rows
     {


### PR DESCRIPTION
Fixes #8.

The `content_margin` was causing the margin. Moreover, since now the icons
need space to fit in, `row_padding` and `indent_offset` were modified.

Moveover, the top level of the sidebar no longer needs to be indented.
This too has been changed.

<sub>NOTE: Some comments by me were deleted as they were no longer relavant.</sub>
