### PR TITLE
fix: correct Gulpfile and Gruntfile scope

### DIFF
--- a/settings/langs/Gruntfile Coffee.tmLanguage
+++ b/settings/langs/Gruntfile Coffee.tmLanguage
@@ -16,6 +16,6 @@
 		</dict>
 	</array>
 	<key>scopeName</key>
-	<string>source.coffee, source.gruntfile.coffee</string>
+	<string>source.coffee.gruntfile</string>
 </dict>
 </plist>

--- a/settings/langs/Gruntfile JS.tmLanguage
+++ b/settings/langs/Gruntfile JS.tmLanguage
@@ -17,6 +17,6 @@
 		</dict>
 	</array>
 	<key>scopeName</key>
-	<string>source.js, source.gruntfile.js</string>
+	<string>source.js.gruntfile</string>
 </dict>
 </plist>

--- a/settings/langs/Gulpfile Coffee.tmLanguage
+++ b/settings/langs/Gulpfile Coffee.tmLanguage
@@ -16,6 +16,6 @@
 		</dict>
 	</array>
 	<key>scopeName</key>
-	<string>source.coffee, source.gulpfile.coffee</string>
+	<string>source.coffee.gulpfile</string>
 </dict>
 </plist>

--- a/settings/langs/Gulpfile JS.tmLanguage
+++ b/settings/langs/Gulpfile JS.tmLanguage
@@ -17,6 +17,6 @@
 		</dict>
 	</array>
 	<key>scopeName</key>
-	<string>source.js, source.gulpfile.js</string>
+	<string>source.js.gulpfile</string>
 </dict>
 </plist>

--- a/settings/prefs/icon_gruntfile.tmPreferences
+++ b/settings/prefs/icon_gruntfile.tmPreferences
@@ -3,7 +3,7 @@
 <plist version="1.0">
     <dict>
         <key>scope</key>
-        <string>source.gruntfile</string>
+        <string>source.js.gruntfile, source.coffee.gruntfile</string>
         <key>settings</key>
         <dict>
             <key>icon</key>

--- a/settings/prefs/icon_gulpfile.tmPreferences
+++ b/settings/prefs/icon_gulpfile.tmPreferences
@@ -3,7 +3,7 @@
 <plist version="1.0">
     <dict>
         <key>scope</key>
-        <string>source.gulpfile</string>
+        <string>source.js.gulpfile, source.coffee.gulpfile</string>
         <key>settings</key>
         <dict>
             <key>icon</key>


### PR DESCRIPTION
The scope must be defined as 'source.js.gruntfile' etc. to correctly inherit
everything from the 'js' syntax, specifically the ability to toggle comments,
which has been broken in these syntaxes.
See https://forum.sublimetext.com/t/toggle-comments-does-not-work-for-custom-languages/16499/3

The icons have also been adjusted to match both Gruntfile.js and Gruntfile.coffee syntax
definitions.

Disclaimer: I'm not super familar with tm preference files, so there might be issues with these changes. I've confirmed manually that commenting now works in these syntaxes and that the icons are correct.