### PR TITLE
Add dark colored window title

### DIFF
--- a/dark/SoDaReloaded Dark.sublime-theme
+++ b/dark/SoDaReloaded Dark.sublime-theme
@@ -1,6 +1,17 @@
 [
 
 //
+// Window Title
+//
+    // Dark Title, same color as the Side Bar
+    {
+        "class": "title_bar",
+        "fg": [215, 218, 224],
+        "bg": [28, 28, 28]
+    }, 
+
+
+//
 // TABS (REGULAR)
 //
 


### PR DESCRIPTION
Sublime 3 now supports modifying the color of the Window Title. With this patch the titlebar uses the same color as the side bar, instead of the default light gray color that simply doesn't fit a dark theme.